### PR TITLE
Fix GEMINI_API_KEY validation rejecting valid keys

### DIFF
--- a/composable_app/keys.env
+++ b/composable_app/keys.env
@@ -1,4 +1,8 @@
-GEMINI_API_KEY=# See https://ai.google.dev/gemini-api/docs/api-key
-OPENAI_API_KEY=# See https://platform.openai.com/api-keys
-HF_TOKEN=#See https://huggingface.co/settings/tokens
-ANTHROPIC_API_KEY=#See https://console.anthropic.com/settings/keys
+# See https://ai.google.dev/gemini-api/docs/api-key
+GEMINI_API_KEY=
+# See https://platform.openai.com/api-keys
+OPENAI_API_KEY=
+# See https://huggingface.co/settings/tokens
+HF_TOKEN=
+# See https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=

--- a/composable_app/utils/llms.py
+++ b/composable_app/utils/llms.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def _setup():
     source_dir = os.path.dirname(os.path.abspath(__file__))
     load_dotenv(f"{source_dir}/../keys.env")
-    assert os.environ["GEMINI_API_KEY"][:2] == "AI", \
+    assert os.environ.get("GEMINI_API_KEY"), \
         "Please specify the GEMINI_API_KEY access token in keys.env file or as an environment variable."
 
     logger.info(f"Defaulting to {DEFAULT_MODEL}; will use {BEST_MODEL} "


### PR DESCRIPTION
## Problem

Running the composable app fails even with a valid Gemini API key:

```
File ".../composable_app/utils/llms.py", line 15, in _setup
    assert os.environ["GEMINI_API_KEY"][:2] == "AI", \
AssertionError: Please specify the GEMINI_API_KEY access token in keys.env file or as an environment variable.
```

`_setup()` asserts that the key starts with `AI`, but newer Gemini API keys no longer use that prefix, so valid keys are rejected.

## Fix

- `utils/llms.py`: replace the brittle prefix check with a presence check (`os.environ.get("GEMINI_API_KEY")`).
- `keys.env`: the placeholders were written as `KEY=# comment`. python-dotenv loads that as the literal non-empty string `"# comment"`, which would slip past a plain presence check. Moved the comments to their own lines and left the values empty, so the helpful "please set your key" error still fires when the key is unset.

## Testing

- Default `keys.env` (no key set) -> assertion fires with the helpful message.
- Real key set (any prefix) -> setup passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)