### PR TITLE
Use models/gemini-embedding-001 for long-term memory embeddings

### DIFF
--- a/composable_app/utils/long_term_memory.py
+++ b/composable_app/utils/long_term_memory.py
@@ -37,7 +37,7 @@ class LongTermMemory:
             "embedder": {
                 "provider": "gemini",
                 "config": {
-                    "model": "models/gemini-embedding-exp-03-07",
+                    "model": "models/gemini-embedding-001",
                     "embedding_dims": 1536
                 }
             },


### PR DESCRIPTION
## Problem

`composable_app/utils/long_term_memory.py` configures mem0 with the embedding model `models/gemini-embedding-exp-03-07`. That experimental preview model has been retired from the Gemini API, so every embedding call now fails:

```
404 NOT_FOUND - models/gemini-embedding-exp-03-07 is not found for API version
v1beta, or is not supported for embedContent.
```

The error is swallowed in `search_relevant_memories`, so long-term memory silently returns nothing instead of surfacing relevant context.

## Fix

Switch to the GA successor `models/gemini-embedding-001` (the model `exp-03-07` graduated into). It supports the same 1536 output dimensions, so no other change is needed. Verified end-to-end against the live API: embedding and mem0 add/search run without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)